### PR TITLE
Removed transmission of garbage data - likely residual from developme…

### DIFF
--- a/example/lib/wifi_screen/wifi_bloc.dart
+++ b/example/lib/wifi_screen/wifi_bloc.dart
@@ -58,9 +58,6 @@ class WiFiBlocSoftAP extends Bloc<WifiEvent, WifiState> {
   Stream<WifiState> _mapProvisioningToState(
       WifiEventStartProvisioningSoftAP event) async* {
     yield WifiStateProvisioning();
-    List<int> customData = utf8.encode("Some CUSTOM data\0");
-    Uint8List customBytes = Uint8List.fromList(customData);
-    await prov.sendReceiveCustomData(customBytes);
     await prov?.sendWifiConfig(ssid: event.ssid, password: event.password);
     await prov?.applyWifiConfig();
     await Future.delayed(Duration(seconds: 1));


### PR DESCRIPTION
…nt/debugging?

Now the example works fine for provisioning an ESP32S2. It did not before.