### PR TITLE
Implement No Auth variant of Security1

### DIFF
--- a/lib/src/security1.dart
+++ b/lib/src/security1.dart
@@ -119,6 +119,10 @@ class Security1 implements Security {
         logger.i(
             'setup0Response: pop: $pop, hash: ${hash.bytes.toString()} sharedK: ${sharedKeyBytes.toString()}');
       }
+      else
+      {
+        sharedKeyBytes = Uint8List.fromList(sharedSecret);
+      }
       await this.crypt.init(sharedKeyBytes, deviceRandom);
       logger.i(
           'setup0Response: cipherSecretKey: ${sharedKeyBytes.toString()} cipherNonce: ${deviceRandom.toString()}');


### PR DESCRIPTION
Fix crash when using second mode of Security1 (without PoP)

[See espressif docs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/provisioning/provisioning.html?highlight=security1#security-schemes).